### PR TITLE
Add scripts to remove obsolete snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
+    "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "lerna run compile",
     "lint": "eslint . && eslint **/*.js, **/*.jsx  && lerna run lint",
     "lint:js": "lerna run lint:js",

--- a/packages/terra-arrange/package.json
+++ b/packages/terra-arrange/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.cerner.com/terra/terra-ui#readme",
   "scripts": {
+    "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "../../node_modules/.bin/babel src --out-dir lib --copy-files",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "../../node_modules/.bin/eslint **/*.js, **/*.jsx",

--- a/packages/terra-button/package.json
+++ b/packages/terra-button/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.cerner.com/terra/terra-ui#readme",
   "scripts": {
+    "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "../../node_modules/.bin/babel src --out-dir lib --copy-files",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "../../node_modules/.bin/eslint **/*.js, **/*.jsx",


### PR DESCRIPTION
### Summary
Add npm-scripts to make it easy to remove obsolete snapshots. Uses the `-u` [alias from jest to update snapshots](https://facebook.github.io/jest/docs/cli.html#updatesnapshot)