### PR TITLE
Add postinstall script to boostrap project after npm install is run

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint:scss": "lerna run lint:scss",
     "jest": "jest",
     "jest:coverage": "jest --coverage",
+    "postinstall": "npm run bootstrap",
     "test": "lerna exec --concurrency 1 npm test",
     "start": "webpack-dev-server --hot --inline --display-error-details --progress --colors --host 0.0.0.0",
     "webpack": "webpack --config webpack.prod.config.js -p --progress --profile --json > build/stats.json",


### PR DESCRIPTION
### Summary
This addition will run `lerna bootsrap` after `npm install` is run.

When run, this command will:
`npm install` all external dependencies of each package.
Symlink together all Lerna packages that are dependencies of each other.
`npm prepublish` all bootstrapped packages.

[More info about the bootstrap command can be found here](https://github.com/lerna/lerna/#bootstrap)
