### PR TITLE
Additional changes to support sauce labs so that we will not be launc…

### DIFF
--- a/packages/terra-button/tests/nightwatch.conf.js
+++ b/packages/terra-button/tests/nightwatch.conf.js
@@ -2,9 +2,8 @@
 
 const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
+const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
 
-module.exports = ((settings) => {
-  const returnSettings = settings;
-  returnSettings.test_settings = testSettings(resolve('../../webpack.config'));
-  return returnSettings;
-})(require('../node_modules/terra-toolkit/lib/nightwatch.json'));
+module.exports = (settings => (
+  testSettings(resolve('../../webpack.config'), settings)
+))(nightwatchConfiguration);

--- a/packages/terra-toolkit/lib/test-settings.js
+++ b/packages/terra-toolkit/lib/test-settings.js
@@ -53,7 +53,7 @@ var drivers = {
   }
 };
 
-module.exports = function (testConfigPath) {
+module.exports = function (testConfigPath, settings) {
   var testingConfiguration = {};
 
   var currentPort = 19000;
@@ -69,5 +69,7 @@ module.exports = function (testConfigPath) {
       currentPort += 1;
     });
   });
-  return testingConfiguration;
+  var returnSettings = settings;
+  returnSettings.test_settings = testingConfiguration;
+  return returnSettings;
 };

--- a/packages/terra-toolkit/nightwatch.conf.js
+++ b/packages/terra-toolkit/nightwatch.conf.js
@@ -4,8 +4,7 @@ const testSettings = require('./lib/index').testSettings;
 const resolve = require('path').resolve;
 
 module.exports = ((settings) => {
-  const returnSettings = settings;
-  returnSettings.test_settings = testSettings(resolve('./tests/test.config'));
+  const returnSettings = testSettings(resolve('./tests/test.config'), settings);
   returnSettings.globals_path = './lib/globals.js';
   return returnSettings;
 })(require('./lib/nightwatch.json'));

--- a/packages/terra-toolkit/src/test-settings.js
+++ b/packages/terra-toolkit/src/test-settings.js
@@ -49,7 +49,7 @@ const drivers = {
   },
 };
 
-module.exports = (testConfigPath) => {
+module.exports = (testConfigPath, settings) => {
   const testingConfiguration = {};
 
   let currentPort = 19000;
@@ -65,5 +65,7 @@ module.exports = (testConfigPath) => {
       currentPort += 1;
     });
   });
-  return testingConfiguration;
+  const returnSettings = settings;
+  returnSettings.test_settings = testingConfiguration;
+  return returnSettings;
 };


### PR DESCRIPTION
…hing the local selenium server if running remote tests.

### Summary
In order to properly interface with sauce labs I want access to all of the night watch settings so I can disable running a local selenium server when running remotely.  The change I have just made will allow for this.  I know this is non-passive but terra-toolkit has yet to be released.