### PR TITLE
Make terra-toolkit public

### DIFF
--- a/packages/terra-toolkit/package.json
+++ b/packages/terra-toolkit/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "Utilities to help when developing terra modules",
   "main": "lib/index.js",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cerner/terra-toolkit.git"


### PR DESCRIPTION
### Summary
We need to remove private from package.json for terra-toolkit so that it can be published.