### PR TITLE
Use pure CSS for ResponsiveElement animation examples

### DIFF
--- a/packages/terra-responsive-element/examples/AnimatedResponsiveElement.jsx
+++ b/packages/terra-responsive-element/examples/AnimatedResponsiveElement.jsx
@@ -14,7 +14,7 @@ const defaultProps = {
 };
 
 const AnimatedResponsiveElement = ({ responsiveTo }) => (
-  <div className="terra-AnimatedResponsiveElement" style={{ border: '1px dashed grey', padding: '5px' }}>
+  <div className="terra-AnimatedResponsiveElement">
     <ResponsiveElement
       responsiveTo={responsiveTo}
       tiny={<div>Tiny</div>}

--- a/packages/terra-responsive-element/examples/AnimatedResponsiveElement.jsx
+++ b/packages/terra-responsive-element/examples/AnimatedResponsiveElement.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import ResponsiveElement from '../src/ResponsiveElement';
+import './AnimatedResponsiveElement.scss';
 
 const propTypes = {
   /**
@@ -12,45 +13,19 @@ const defaultProps = {
   responsiveTo: 'parent',
 };
 
-class AnimatedResponsiveElement extends React.Component {
-  constructor() {
-    super();
-    this.state = { width: '20%' };
-    this.interval = null;
-  }
-
-  componentDidMount() {
-    setTimeout(() => this.setState({ width: '100%' }), 1000);
-    this.interval = setInterval(() => { this.setState({ width: (this.state.width === '100%' ? '20%' : '100%') }); }, 5000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-    this.interval = null;
-  }
-
-  render() {
-    const tiny = <div>Tiny</div>;
-    const small = <div>Small</div>;
-    const medium = <div>Medium</div>;
-    const large = <div>Large</div>;
-    const huge = <div>Huge</div>;
-    const defaultElement = <div>Default</div>;
-    return (
-      <div style={{ width: this.state.width, border: '1px dashed grey', padding: '5px', transition: 'all 5.0s ease-in-out' }}>
-        <ResponsiveElement
-          responsiveTo={this.props.responsiveTo}
-          tiny={tiny}
-          small={small}
-          medium={medium}
-          large={large}
-          huge={huge}
-          defaultElement={defaultElement}
-        />
-      </div>
-    );
-  }
-}
+const AnimatedResponsiveElement = ({ responsiveTo }) => (
+  <div className="terra-AnimatedResponsiveElement" style={{ border: '1px dashed grey', padding: '5px' }}>
+    <ResponsiveElement
+      responsiveTo={responsiveTo}
+      tiny={<div>Tiny</div>}
+      small={<div>Small</div>}
+      medium={<div>Medium</div>}
+      large={<div>Large</div>}
+      huge={<div>Huge</div>}
+      defaultElement={<div>Default</div>}
+    />
+  </div>
+);
 
 AnimatedResponsiveElement.propTypes = propTypes;
 AnimatedResponsiveElement.defaultProps = defaultProps;

--- a/packages/terra-responsive-element/examples/AnimatedResponsiveElement.scss
+++ b/packages/terra-responsive-element/examples/AnimatedResponsiveElement.scss
@@ -1,5 +1,7 @@
 .terra-AnimatedResponsiveElement {
   animation: grow-and-shrink 10s infinite;
+  border: 1px dashed;
+  padding: 5px;
 }
 
 @keyframes grow-and-shrink {

--- a/packages/terra-responsive-element/examples/AnimatedResponsiveElement.scss
+++ b/packages/terra-responsive-element/examples/AnimatedResponsiveElement.scss
@@ -1,0 +1,9 @@
+.terra-AnimatedResponsiveElement {
+  animation: grow-and-shrink 10s infinite;
+}
+
+@keyframes grow-and-shrink {
+  0% { width: 20%; }
+  50% { width: 100%; }
+  100% { width: 20%; }
+}

--- a/packages/terra-responsive-element/examples/Responsive.jsx
+++ b/packages/terra-responsive-element/examples/Responsive.jsx
@@ -25,11 +25,11 @@
      />
         );
    return (
-     <div style={{ border: '1px dashed grey', width: '100%', marginTop: '10px', padding: '5px' }}>
-       <div style={{ borderRight: '1px dashed grey', display: 'inline-block', width: '20%', padding: '5px' }}>
+     <div style={{ border: '1px dashed', width: '100%', marginTop: '10px', padding: '5px' }}>
+       <div style={{ borderRight: '1px dashed', display: 'inline-block', width: '20%', padding: '5px' }}>
          {responsiveElement}
        </div>
-       <div style={{ borderRight: '1px dashed grey', display: 'inline-block', width: '50%', padding: '5px' }}>
+       <div style={{ borderRight: '1px dashed', display: 'inline-block', width: '50%', padding: '5px' }}>
          {responsiveElement}
        </div>
        <div style={{ display: 'inline-block', width: '20%', padding: '5px' }}>

--- a/packages/terra-responsive-element/examples/Responsive.jsx
+++ b/packages/terra-responsive-element/examples/Responsive.jsx
@@ -13,21 +13,15 @@
  };
 
  const Responsive = ({ responsiveTo }) => {
-   const tiny = <div>Tiny</div>;
-   const small = <div>Small</div>;
-   const medium = <div>Medium</div>;
-   const large = <div>Large</div>;
-   const huge = <div>Huge</div>;
-   const defaultElement = <div>Default</div>;
    const responsiveElement = (
      <ResponsiveElement
        responsiveTo={responsiveTo}
-       defaultElement={defaultElement}
-       tiny={tiny}
-       small={small}
-       medium={medium}
-       large={large}
-       huge={huge}
+       defaultElement={<div>Default</div>}
+       tiny={<div>Tiny</div>}
+       small={<div>Small</div>}
+       medium={<div>Medium</div>}
+       large={<div>Large</div>}
+       huge={<div>Huge</div>}
      />
         );
    return (


### PR DESCRIPTION
### Summary
One of the examples for ResponsiveElement wasn't unregistering a function and would log a warning when unmounted.

I removed all state from the Examples and use pure css for animating.

Thanks for contributing to Terra. 
@cerner/terra