### PR TITLE
Add clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
+    "clean:all": "rm -rf ./node_modules && rm -rf ./packages/*/node_modules",
     "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "lerna run compile",
     "deploy": "lerna run --scope terra-site deploy",
@@ -44,6 +45,7 @@
     "jest": "jest",
     "jest:coverage": "jest --coverage",
     "pretest": "npm run lint",
+    "preinstall": "npm run clean:all",
     "postinstall": "npm run bootstrap",
     "test": "lerna exec --concurrency 1 npm test",
     "prepush": "node scripts/prepush/index.js",


### PR DESCRIPTION
### Summary
Adding a clean task to remove root directory `node_modules` and package directory `node_modules`. This can be run at any time. I've also hooked into the npm install lifecycle. When a user runs `npm install`, the script will clean all the `node_modules` directories, then npm will install new modules into `node_modules` directories. This will increase npm install times (npm won't be able to install only new items, it will install all items in package.json) but it should fix weird caching issues we've seen recently.

https://github.com/cerner/terra-ui/issues/142