### PR TITLE
Update links to fix a11y issues

### DIFF
--- a/src/terra-dev-site/home/HomeHero.jsx
+++ b/src/terra-dev-site/home/HomeHero.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Particles from 'react-particles-js';
-import { NavLink } from 'react-router-dom';
 import HomeHeroConfig from './HomeHeroConfig';
 import imgTerra from './assets/terra-ui.png';
 import styles from './HomeHero.scss';
@@ -13,7 +12,7 @@ const HomeHero = () => (
       <Particles style={particleStyle} params={HomeHeroConfig} />
       <div className={styles['hero-content']}>
         <h1 className={styles['hero-title']}>Terra UI</h1>
-        <NavLink className={styles['hero-button']} to="/getting-started">Get Started</NavLink>
+        <a className={styles['hero-button']} href="https://engineering.cerner.com/terra-ui/#/getting-started/terra-ui/what-is-terra">Get Started</a>
       </div>
     </div>
   </section>

--- a/src/terra-dev-site/home/HomeMoreInfo.jsx
+++ b/src/terra-dev-site/home/HomeMoreInfo.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
 import Grid from 'terra-grid';
 import Heading from 'terra-heading';
 import Text from 'terra-text';
@@ -9,24 +8,24 @@ const HomeAdditionalPages = () => (
   <Grid className={styles.section}>
     <Grid.Row>
       <Grid.Column col={12} small={6}>
-        <NavLink className={styles.link} to="getting-started"><Heading level={2}>Getting Started</Heading></NavLink>
+        <Heading level={2}>Getting Started</Heading>
         <div style={{ marginTop: '.5rem' }}>
           <Text fontSize={18}>
             Want to learn more about Terra UI? Check out the
             {' '}
-            <NavLink to="/getting-started">Getting Started Guide</NavLink>
+            <a href="https://engineering.cerner.com/terra-ui/#/getting-started/terra-ui/what-is-terra">Getting Started Guide</a>
             {' '}
             to learn more about the following: component features, usage, installation, configuration, and more.
           </Text>
         </div>
       </Grid.Column>
       <Grid.Column col={12} small={6}>
-        <NavLink className={styles.link} to="components"><Heading level={2}>Components</Heading></NavLink>
+        <Heading level={2}>Components</Heading>
         <div style={{ marginTop: '.5rem' }}>
           <Text fontSize={18}>
             Terra UI offers a wide range of components - from common UI components to specialized components designed for clinical use.
             {' '}
-            <NavLink to="/components">View the entire library</NavLink>
+            <a href="https://engineering.cerner.com/terra-ui/#/components">View the entire library</a>
             .
           </Text>
         </div>


### PR DESCRIPTION
### Summary
Update links on homepage to fix accessibility issues.

**Before**
<img width="1315" alt="screen shot 2019-01-31 at 2 10 05 pm" src="https://user-images.githubusercontent.com/633148/52082309-145a5d80-2562-11e9-91d5-a6f5bdb26403.png">

**After**
<img width="1315" alt="screen shot 2019-01-31 at 2 10 19 pm" src="https://user-images.githubusercontent.com/633148/52082310-145a5d80-2562-11e9-91c7-f119879d6fe3.png">

This does hard-code links to point to the production site so they won't link to local site when running the project locally. 