### PR TITLE
[terra-ui] Documentation updates for changes in responsive element sizing nomenclature 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Cerner Corporation
 - Dave Kasper [@dkasper-was-taken]
 - Brett Jankord [@bjankord]
 - Jaime Mackey [@jmsv6d]
+- Avinash Gupta [@avinashg1994]
 
 [@matt-butler]: https://github.com/matt-butler
 [@windse7en]:https://github.com/windse7en
@@ -19,3 +20,4 @@ Cerner Corporation
 [@dkasper-was-taken]: https://github.com/dkasper-was-taken
 [@bjankord]: https://github.com/bjankord
 [@jmsv6d]: https://github.com/jmsv6d
+[avinashg1994]: https://github.com/avinashg1994

--- a/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md
+++ b/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md
@@ -34,11 +34,12 @@ Components should work responsively without introducing horizontal scrollbars on
 Terra components are built following the mobile-first approach and utilize the following media query breakpoints:
 
  - Default: Applies to all viewport widths.
- - Tiny: `@media screen and (min-width: 544px)` Applies to screen viewport width 544px and wider.
- - Small: `@media screen and (min-width: 768px)` Applies to screen viewport width 768px and wider.
- - Medium: `@media screen and (min-width: 992px)` Applies to screen viewport width 992px and wider.
- - Large: `@media screen and (min-width: 1216px)` Applies to screen viewport width 1216px and wider.
- - Huge: `@media screen and (min-width: 1440px)` Applies to screen viewport width 1440px and wider.
+ - Tiny: `@media screen and (min-width: 0px)` Applies to screen viewport width 0px and wider.
+ - Small: `@media screen and (min-width: 544px)` Applies to screen viewport width 544px and wider.
+ - Medium: `@media screen and (min-width: 768px)` Applies to screen viewport width 768px and wider.
+ - Large: `@media screen and (min-width: 992px)` Applies to screen viewport width 992px and wider.
+ - Huge: `@media screen and (min-width: 1216px)` Applies to screen viewport width 1216px and wider.
+ - Enormous: `@media screen and (min-width: 1440px)` Applies to screen viewport width 1440px and wider.
 
 ## Mobile Support
 


### PR DESCRIPTION
### Summary
Updated documentation to reflect changes in responsive-element sizing nomenclature.
Can be verified here : [Link](https://github.com/cerner/terra-ui/blob/issue-189-responsive-sizing-documentation/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md)

Resolves #189