### PR TITLE
Remove mention of Arabic support

### DIFF
--- a/src/terra-dev-site/contributing/ComponentStandards.e.contributing.mdx
+++ b/src/terra-dev-site/contributing/ComponentStandards.e.contributing.mdx
@@ -91,7 +91,6 @@ Components should include [Jest](https://github.com/facebook/jest) tests and [We
 
 Components should be internationalized and support the following locales:
 
-* Arabic `ar`
 * English `en`
 * English (Australia) `en-AU`
 * English (Canada) `en-CA`


### PR DESCRIPTION
### Summary
We dropped Arabic support a while back: https://github.com/cerner/terra-aggregate-translations/pull/2

This conversation was broke up on this PR to remove its mention on terra-ui: https://github.com/cerner/terra-clinical/pull/624#discussion_r393040889
