### PR TITLE
master -> main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - npm test
 branches:
   only:
-    - master
+    - main
 before_deploy:
   - TERRA_DEV_SITE_NEW_RELIC_LICENSE_KEY='c494ac44c8' TERRA_DEV_SITE_NEW_RELIC_APPLICATION_ID='142381315' TERRA_DEV_SITE_PUBLIC_PATH='/terra-ui/' npm run build:production
 deploy:
@@ -14,4 +14,4 @@ deploy:
   github_token: $GITHUB_TOKEN
   local_dir: build
   on:
-    branch: master
+    branch: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 ## Issue Reporting
 
 * Please browse our [existing issues](https://github.com/cerner/terra-ui/issues) before logging new issues.
-* Check that the issue has not already been fixed in the `master` branch.
+* Check that the issue has not already been fixed in the `main` branch.
 * Open an issue with a descriptive title and a summary.
 * Please be as clear and explicit as you can in your description of the problem.
 * Please state the version of Operating System, Browser, and the version you are using in the description.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@
    - [Implementers](#implementers)
    - [The Community](#the-community)
 - [Contributions](#contributions)
-  - [Master branch](#master-branch)
+  - [Main branch](#main-branch)
   - [Feature branches](#feature-branches)
   - [Forks](#forks)
 - [Voting and Consensus](#voting-and-consensus)
@@ -46,7 +46,7 @@ The current Maintainers on the project are:
 
 ### Committers
 
-The committers are individuals who have demonstrated an active role in the terra community and commit to the project regularly. They are given access to create branches within Terra projects and merge branches to master after checks and reviews have completed. They do not have access to push directly to master. Committers may be removed after long periods of inactivity.
+The committers are individuals who have demonstrated an active role in the terra community and commit to the project regularly. They are given access to create branches within Terra projects and merge branches to main after checks and reviews have completed. They do not have access to push directly to main. Committers may be removed after long periods of inactivity.
 
 ### Contributors
 
@@ -68,9 +68,9 @@ Any existing maintainer may nominate a contributor to be a new maintainer on the
 
 Anyone is welcome to contribute to the project. All contributions are public and associated to the individual(s) submitting the change.
 
-### Master branch
+### main branch
 
-The master branch must be kept in a releasable state.
+The main branch must be kept in a releasable state.
 
 Trivial changes may be committed directly to a repository. Changes deemed trivial are things like small documentation typos, ecosystem changes (eg, CI configuration, linting rules), etc. Obviously, *trivial* is subjective and anyone is welcome to comment directly on such changes or open an issue regarding them.
 
@@ -106,13 +106,13 @@ Large
 
 Committers should use feature branches to work on in-progress features and changes. Committers may commit directly to feature branches at any time and without prior review.
 
-Committers can submit a pull request from their feature branch to the master branch for review.
+Committers can submit a pull request from their feature branch to the main branch for review.
 
 ### Forks
 
 As contributors do not have write access to the repository, their contributions must be done from personal forks.
 
-Contributors can submit a pull request from their fork to the upstream master branch for review.
+Contributors can submit a pull request from their fork to the upstream main branch for review.
 
 ## Voting and Consensus
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- Logo -->
 <p align="center">
-  <img height="128" width="128" src="https://raw.githubusercontent.com/cerner/terra-core/master/terra.png">
+  <img height="128" width="128" src="https://raw.githubusercontent.com/cerner/terra-core/main/terra.png">
 </p>
 
 <!-- Name -->

--- a/src/terra-dev-site/about/Releases.c.about.mdx
+++ b/src/terra-dev-site/about/Releases.c.about.mdx
@@ -4,11 +4,11 @@ Terra is a hyper-modularized framework. Each component has its own version and a
 
 ## Weekly Releases
 
-Terra will release any component that has had changes reviewed and merged into master the last week. Generally we release mid week on Tuesday or Wednesday.
+Terra will release any component that has had changes reviewed and merged into main the last week. Generally we release mid week on Tuesday or Wednesday.
 
 ### One-offs released as needed
 
-We keep our master branch in an always release-able state to enable quick turnaround time.
+We keep our main branch in an always release-able state to enable quick turnaround time.
 
 ## Bugs
 

--- a/src/terra-dev-site/about/contributing.d/ContributionGuidelines.a.about.mdx
+++ b/src/terra-dev-site/about/contributing.d/ContributionGuidelines.a.about.mdx
@@ -64,7 +64,7 @@ A Terra engineer must be allocated to help guide the contribution. How much of t
 
 ## Long Term Maintenance
 
-After the contribution is merged into master, Terra will take on ownership of the contribution.  This ownership will include:
+After the contribution is merged into main, Terra will take on ownership of the contribution.  This ownership will include:
 
 - Support
 - Releases

--- a/src/terra-dev-site/about/contributing.d/Conventions.f.about.mdx
+++ b/src/terra-dev-site/about/contributing.d/Conventions.f.about.mdx
@@ -405,4 +405,4 @@ Terra.should.themeCombinationOfCustomProperties({
     });
 ````
 
-You can find more info on writing webdriver.io tests for terra [here](https://github.com/cerner/terra-toolkit-boneyard/blob/master/docs/Wdio_Utility.md#writing-tests).
+You can find more info on writing webdriver.io tests for terra [here](https://github.com/cerner/terra-toolkit-boneyard/blob/main/docs/Wdio_Utility.md#writing-tests).

--- a/src/terra-dev-site/about/contributing.d/DeveloperWorkflow.e.about.mdx
+++ b/src/terra-dev-site/about/contributing.d/DeveloperWorkflow.e.about.mdx
@@ -6,7 +6,7 @@ import CodeReviewIcon from '../../icon/CodeReviewIcon';
 <div className="tui-illustration-grid-col">
 
 ## Create Tech Design
-It's good to create a tech design on the related GitHub issue you'll be working on. This allows for discussion with the [terra team](https://github.com/orgs/cerner/teams/terra) before getting deep into development. Once you feel the tech design has been landed on, feel free to open up a pull request. Based on the changes introduced in the PR, the change will either be considered a small or large change and follow review guidelines documented in the [terra governance modal](https://github.com/cerner/terra-ui/blob/master/GOVERNANCE.md).
+It's good to create a tech design on the related GitHub issue you'll be working on. This allows for discussion with the [terra team](https://github.com/orgs/cerner/teams/terra) before getting deep into development. Once you feel the tech design has been landed on, feel free to open up a pull request. Based on the changes introduced in the PR, the change will either be considered a small or large change and follow review guidelines documented in the [terra governance modal](/about/terra-ui/governance-model).
 
 Incorporate feedback you receive from tech design review into your implementation. It's helpful to update the tech design with feedback you incorporate.
 
@@ -145,7 +145,7 @@ Change directories to the specific package in your terminal, e.g. `cd packages/t
 
 `npm run test:wdio`
 
-More info on writing webdriver.io tests for terra can be [found here](https://github.com/cerner/terra-toolkit-boneyard/blob/master/docs/Wdio_Utility.md).
+More info on writing webdriver.io tests for terra can be [found here](https://github.com/cerner/terra-toolkit-boneyard/blob/main/docs/Wdio_Utility.md).
 
 _If you make changes to code inside of the `src` directories, and you do not see if reflected in tests, run `npm run compile` to ensure your tests are using the latest code changes._
 

--- a/src/terra-dev-site/about/contributing.d/DevelopmentPrerequisites.c.about.mdx
+++ b/src/terra-dev-site/about/contributing.d/DevelopmentPrerequisites.c.about.mdx
@@ -10,7 +10,7 @@ The following sections are helpful to be familiar with before starting a contrib
 ## Licensing
 
 All files are released with the Apache 2.0 licence.
-Please add your name to the CONTRIBUTORS.md file in the repo you are contributing to. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the [License](https://github.com/cerner/terra-ui/blob/master/LICENSE).
+Please add your name to the CONTRIBUTORS.md file in the repo you are contributing to. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the [License](https://github.com/cerner/terra-ui/blob/main/LICENSE).
 
 </div>
 <div className="tui-illustration-grid-col tui-illustration-grid-col-illustration">

--- a/src/terra-dev-site/about/contributing.d/GitWorkflow.d.about.mdx
+++ b/src/terra-dev-site/about/contributing.d/GitWorkflow.d.about.mdx
@@ -13,10 +13,10 @@ _Note: The [terra team](https://github.com/orgs/cerner/teams/terra) and [terra c
 
 ## Creating A Branch
 
-Before starting your work, first ensure you're in the master branch and that you've pulled down the latest changes:
+Before starting your work, first ensure you're in the main branch and that you've pulled down the latest changes:
 
 ```sh
-git checkout master
+git checkout main
 git pull
 ```
 
@@ -37,7 +37,7 @@ Read through our [development workflow guide](/about/terra-ui/contributing/devel
 ## Adding, Committing, And Pushing Changes
 
 Git commit to the local branch and git push to the remote branch. [Write good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
-Your commits will automatically be squashed when your PR is merged into master.
+Your commits will automatically be squashed when your PR is merged into main.
 
 This will commit your changes to your local copy of the repo.
 
@@ -56,7 +56,7 @@ We use [Github pull requests](https://help.github.com/articles/about-pull-reques
 
 ### Submit A Pull Request
 
-When your branch is ready, open a new pull request via GitHub. The repo [PR template](https://github.com/cerner/terra-ui/blob/master/.github/PULL_REQUEST_TEMPLATE.md) will guide you toward describing your contribution.
+When your branch is ready, open a new pull request via GitHub. The repo [PR template](https://github.com/cerner/terra-ui/blob/main/.github/PULL_REQUEST_TEMPLATE.md) will guide you toward describing your contribution.
 
 You can [use words in PR description that refrence the related issue](https://help.github.com/articles/closing-issues-using-keywords/) and will automatically close it when the PR is merged.
 
@@ -64,7 +64,7 @@ For example, to close an issue numbered `123`, you could use the phrase `Closes 
 
 ### Code Review
 
-Per our [terra governance model](https://github.com/cerner/terra-ui/blob/master/GOVERNANCE.md), changes must be reviewed by the maintainers. This includes contributions from the community, as well as the current maintainers.
+Per our [terra governance model](https://github.com/cerner/terra-ui/blob/main/GOVERNANCE.md), changes must be reviewed by the maintainers. This includes contributions from the community, as well as the current maintainers.
 
 In order for your pull request to be accepted, the [Travis CI](https://travis-ci.org/) build needs to pass.
 
@@ -113,7 +113,7 @@ We use [GitHub project boards](https://help.github.com/articles/about-project-bo
 
 Once everything is good on the PR, an individual from the [terra team](https://github.com/orgs/cerner/teams/terra) will merge your change in!
 
-After the PR has been merged into master, the PR branch will be deleted.
+After the PR has been merged into main, the PR branch will be deleted.
 
 ## Versioning
 
@@ -127,4 +127,4 @@ For more information on versioning, check out [https://semver.npmjs.com/](https:
 
 ## Releases
 
-At that point, your contribution will be available in the next official release of Terra. Releases happen on weekly basis, whatever is ready in the master branch gets released. If you have any questions at all, don't hesitate to get in touch. We love to talk all things terra and we look forward to seeing your contribution!
+At that point, your contribution will be available in the next official release of Terra. Releases happen on weekly basis, whatever is ready in the main branch gets released. If you have any questions at all, don't hesitate to get in touch. We love to talk all things terra and we look forward to seeing your contribution!

--- a/src/terra-dev-site/guide/Internationalization/AddingTranslations.b.guide.mdx
+++ b/src/terra-dev-site/guide/Internationalization/AddingTranslations.b.guide.mdx
@@ -1,6 +1,6 @@
 # Adding Translations To Components
 
-When adding translations to a component, we recommend putting the translations in a directory named `translations`. The aggregate translations tool will look for translations in [the following directories](https://github.com/cerner/terra-aggregate-translations/blob/master/config/defaultSearchPatterns.js) by default. The default search pattern will look for translations a maximum of three levels deep.
+When adding translations to a component, we recommend putting the translations in a directory named `translations`. The aggregate translations tool will look for translations in [the following directories](https://github.com/cerner/terra-aggregate-translations/blob/main/config/defaultSearchPatterns.js) by default. The default search pattern will look for translations a maximum of three levels deep.
 
 Here is an example directory setup:
 

--- a/src/terra-dev-site/guide/Internationalization/AddingTranslationsForALocaleNotSupportedByTerraUI.d.guide.mdx
+++ b/src/terra-dev-site/guide/Internationalization/AddingTranslationsForALocaleNotSupportedByTerraUI.d.guide.mdx
@@ -1,6 +1,6 @@
 # Adding Translations For A Locale Not Supported By Terra
 
-Terra provides translations for [the following locales](https://github.com/cerner/terra-aggregate-translations/blob/master/config/i18nSupportedLocales.js) for any string used in our components. In some cases, you may need to support locales outside of the ones we provide by default. This is possible, however one must ensure the locales are supported by `react-intl`, otherwise no locale-data will exist and loading the intl data will result in an error. Once confirmed that the locale is supported by `react-intl`, one is responsible for including the appropriate translations messages for each terra component used in your application, otherwise the translations will fail and `react-intl` will display the message name as the fallback.
+Terra provides translations for [the following locales](https://github.com/cerner/terra-aggregate-translations/blob/main/config/i18nSupportedLocales.js) for any string used in our components. In some cases, you may need to support locales outside of the ones we provide by default. This is possible, however one must ensure the locales are supported by `react-intl`, otherwise no locale-data will exist and loading the intl data will result in an error. Once confirmed that the locale is supported by `react-intl`, one is responsible for including the appropriate translations messages for each terra component used in your application, otherwise the translations will fail and `react-intl` will display the message name as the fallback.
 
 As an example, let's say you need to support Polish (`pl`) in your app.
 
@@ -24,7 +24,7 @@ const supportedLocales = require('terra-aggregate-translations/config/i18nSuppor
 aggregateTranslations({ locales: [...supportedLocales, 'pl']});
 ```
 
-Similarly, if leveraging [Terra's default webpack configuration](https://github.com/cerner/terra-toolkit-boneyard/blob/master/config/webpack/webpack.config.js), [you can add a `terraI18n.config.js` file to the root of your project with options to pass to aggregate-translations when its called](https://github.com/cerner/terra-aggregate-translations#terrai18nconfig-example).
+Similarly, if leveraging [Terra's default webpack configuration](https://github.com/cerner/terra-toolkit-boneyard/blob/main/config/webpack/webpack.config.js), [you can add a `terraI18n.config.js` file to the root of your project with options to pass to aggregate-translations when its called](https://github.com/cerner/terra-aggregate-translations#terrai18nconfig-example).
 
 **Note** *When aggregating a locale not supported by Terra, you will see two types of warning messages*
 

--- a/src/terra-dev-site/guide/Internationalization/BuildingComponentsWhichIncludeTranslations.e.guide.mdx
+++ b/src/terra-dev-site/guide/Internationalization/BuildingComponentsWhichIncludeTranslations.e.guide.mdx
@@ -111,4 +111,4 @@ Input.propTypes = propTypes;
 export default injectIntl(Input);
 ```
 
-The react-intl repo contains additional examples that cover using variables, plurals, numbers, and additional use-cases which can be [found here](https://github.com/yahoo/react-intl/tree/master/examples).
+The react-intl repo contains additional examples that cover using variables, plurals, numbers, and additional use-cases which can be [found here](https://github.com/yahoo/react-intl/tree/main/examples).

--- a/src/terra-dev-site/guide/Internationalization/InternationalizationIntro.a.guide.mdx
+++ b/src/terra-dev-site/guide/Internationalization/InternationalizationIntro.a.guide.mdx
@@ -54,7 +54,7 @@ const locale = (navigator.languages && navigator.languages[0])
 
 This will load the `en` translations for any Terra components you use in your app.
 
-**Note:** *This requires running the [terra-aggregate-translations tool](https://github.com/cerner/terra-aggregate-translations/blob/master/README.md) before starting your server to fully work. See the terra aggregate translation section below for more info.*
+**Note:** *This requires running the [terra-aggregate-translations tool](https://github.com/cerner/terra-aggregate-translations/blob/main/README.md) before starting your server to fully work. See the terra aggregate translation section below for more info.*
 
 If your app has custom translations outside of the ones provided by Terra, you can set up and use Terra Application Base as follows:
 

--- a/src/terra-dev-site/tool/DockerDevelopmentEnvironment.tool.mdx
+++ b/src/terra-dev-site/tool/DockerDevelopmentEnvironment.tool.mdx
@@ -1,28 +1,36 @@
-## Docker Development Environment
+# Docker Development Environment
 
 Terra provides a docker development environment that allows developers access to a common environment to develop Terra components regardless of the OS they are developing on.
 
-### Services
+## Services
+
 In each Terra repository there is a docker-compose.yml file that defines several services, most importantly ```dev```.
 
-#### Dev Service
-The dev service provides a linux environment with node, npm and the zsh termianl pre-installed. By default the dev service volume mounts the entire local repo directory into the docker container to enable hot reloading during development.
+### Dev Service
 
-#### Standalone Chrome Service
+The dev service provides a linux environment with node, npm and the zsh terminal pre-installed. By default the dev service volume mounts the entire local repo directory into the docker container to enable hot reloading during development.
+
+### Standalone Chrome Service
+
 Terra's webdriver.io integration tests must run against selenium standalone-chrome node, so this service is required to run wdio tests. It is started alongside the dev and test-ci services.
 
-### Sharing ```node_modules```
-The docker development environment intentionally will write out ```node_modules``` to the shared host volume. This provides several benefits:
-* Simpler volume mounting, everything edited in the repo is shared to the docker container.
-* Node module cacheing. For the development containers ```npm install``` is run at run time of the docker container (opposed to build time). This is done to allow ```npm install``` to discover local dependencies. To avoid long startup times ```node_modules``` are cached to the local volume. If ```node_modules``` are found ```npm install``` is not run at run time.
+## Sharing ```node_modules```
 
-### Before Development
+The docker development environment intentionally will write out ```node_modules``` to the shared host volume. This provides several benefits:
+
+* Simpler volume mounting, everything edited in the repo is shared to the docker container.
+* Node module caching. For the development containers ```npm install``` is run at run time of the docker container (opposed to build time). This is done to allow ```npm install``` to discover local dependencies. To avoid long startup times ```node_modules``` are cached to the local volume. If ```node_modules``` are found ```npm install``` is not run at run time.
+
+## Before Development
+
 To build all the services in the docker-compose file, run:
-```
+
+```bash
 docker-compose build
 ```
 
-### Develping
+## Developing
+
 To get started developing with the dev service, run:
 
 ```bash
@@ -31,24 +39,28 @@ docker-compose run --service-ports dev
 
 This will start the docker container for the repo, run npm install (if ```node_modules``` are not detected)  and then launch the zsh terminal. Then you're free to use your favorite editor to manipulate the code in the repo. Simply run ```npm run start``` once the terminal has launched to start the server.
 
-### Testing
+## Testing
+
 It is required to use the ```--service-ports``` flag when running either service to run wdio tests from the docker container. This maps the service's ports to the host.
 
+## After development
 
-### After development
 After you've finished running development (or periodically), run:
+
 ```bash
 docker-compose down
 ```
+
 This will stop the standalone-chrome service that will otherwise be left running on your device.
 
+## Using Local Dependencies
 
-### Using Local Dependencies
 Local dependencies are supported in the docker development environment, but require an additional step. For the docker container to be able to find the local dependency, it must be volume mounted to the docker container from the dev service.
 
 For example:
 
 package.json
+
 ```json
 "dependencies": {
     "classnames": "file:../classnames",
@@ -56,6 +68,7 @@ package.json
 ```
 
 docker-compose.yml
+
 ```diff
 dev:
   image: "terra-ui:dev"
@@ -71,16 +84,20 @@ dev:
 +    - ../classnames:/opt/classnames
 ```
 
-### Other Ways to Run the Zsh Terminal
+## Other Ways to Run the Zsh Terminal
+
 It is also possible to run the Zsh terminal on a docker container. To attach to a running docker container, run:
 
-```
+```bash
 docker exec -it <hash for running docker container> /bin/zsh
 ```
 
-### Troubleshooting
-#### Error: Missing binding
+## Troubleshooting
+
+### Error: Missing binding
+
 This error means that a node_module install for one environment is being run in another. Likely this means that you ran npm install on your host OS and are now trying to use that module in your docker container or the opposite. To resolve the issue delete the ```node_modules``` folder and run npm_install where you are attempting to start the server.
 
-#### Dependency changes not taking effect.
-npm install is triggered at run time of the docker container. If a ```node_modules``` directory is found npm install will not run. If dependencies have changed the script checking for ```node_modules``` isn't smart enough to re-run npm install. To resolve the issue either terminate the servcie and run npm install or delete the ```node_modules``` folder and rerun the docker container.
+### Dependency changes not taking effect
+
+npm install is triggered at run time of the docker container. If a ```node_modules``` directory is found npm install will not run. If dependencies have changed the script checking for ```node_modules``` isn't smart enough to re-run npm install. To resolve the issue either terminate the service and run npm install or delete the ```node_modules``` folder and rerun the docker container.


### PR DESCRIPTION
### Summary
Using main instead of master terminology, closes #280 

### Additional Details
Theres a bonus update to the docker development guide, just spelling and formatting that i happened to have on my terra-ui branch.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
