### PR TITLE
Work around optional chaining bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
-    "@babel/core": "^7.5.0",
+    "@babel/core": "7.10.5",
+    "@babel/parser": "7.10.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.0",
     "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "^7.5.0",


### PR DESCRIPTION
### Summary

As a workaround for https://github.com/babel/babel/issues/11908 and https://github.com/reactjs/react-docgen/issues/463
lock in the version of babel-core and babel-parser

### Additional Details
Ideally this would be temporary.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
