### PR TITLE
Remove terra-props-table dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "terra-popup": "^6.0.0",
     "terra-profile-image": "^3.0.0",
     "terra-progress-bar": "^4.0.0",
-    "terra-props-table": "^2.0.0",
     "terra-responsive-element": "^5.0.0",
     "terra-scroll": "^2.0.0",
     "terra-search-field": "^3.0.0",

--- a/src/terra-dev-site/IssueForm/Packages.json
+++ b/src/terra-dev-site/IssueForm/Packages.json
@@ -42,7 +42,6 @@
         "terra-paginator",
         "terra-profile-image",
         "terra-progress-bar",
-        "terra-props-table",
         "terra-responsive-element",
         "terra-scroll",
         "terra-search-field",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const path = require('path');
 const webpackConfig = (env, argv) => {
   const config = defaultWebpackConfig(env, argv);
 
-  const propsTable = path.resolve(path.join(process.cwd(), 'node_modules', 'terra-props-table'));
   const momentAlias = path.resolve(path.join(process.cwd(), 'node_modules', 'moment'));
   const intl = path.resolve(path.join(process.cwd(), 'node_modules', 'intl'));
   const terraMarkdown = path.resolve(path.join(process.cwd(), 'node_modules', 'terra-markdown'));
@@ -16,7 +15,6 @@ const webpackConfig = (env, argv) => {
 
   config.stats = 'normal';
   config.resolve.alias = {};
-  config.resolve.alias['terra-props-table'] = propsTable;
   config.resolve.alias['terra-markdown'] = terraMarkdown;
   config.resolve.alias['terra-date-picker'] = terraDatePicker;
   config.resolve.alias.moment = momentAlias;


### PR DESCRIPTION
### Summary
We don't use it, and it ends up duplicating core-js.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
