### PR TITLE
Require node 12 and remove dave as a code owner.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Set default code owners for all files in repo
-* @mjhenkes @ryanthemanuel @tbiethman @dkasper-was-taken
+* @mjhenkes @ryanthemanuel @tbiethman

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/erbium

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -39,7 +39,6 @@ The maintainers are individuals who are recognized by merit and have a demonstra
 
 The current Maintainers on the project are:
 
-- [Dave Kasper](https://github.com/dkasper-was-taken)
 - [Matt Henkes](https://github.com/mjhenkes)
 - [Ryan Manuel](https://github.com/rfmanuel)
 - [Tyler Biethman](https://github.com/tbiethman)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/cerner/terra-ui/issues"
   },
   "engines": {
-    "node": ">=12 <16"
+    "node": ">=12 <15"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/cerner/terra-ui/issues"
   },
   "engines": {
-    "node": ">=8.9.2 <12"
+    "node": ">=12 <16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

terra-toolkit-docs now relies on terra-functional-testing 2 which won't build on node 12. Technically I think it was non passive to update that dependency without major versioning, but oh well, we're the only ones affected.

We also remove @dkasper-was-taken, so long sailor.

![](https://media.giphy.com/media/l0G18RV0eml3kyRFK/giphy.gif)


### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
