### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Set default code owners for all files in repo
-* @benbcai @jmsv6d @elliott-hoffman-cerner
+* @cerner/terra-code-owners


### PR DESCRIPTION
Same as always - manage the @cerner/terra-code-owners team, not every repo's code owners individually.