### PR TITLE
Revert "Updates react-intl to V5 and webpack-dev-server to v4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "deploy": "gh-pages -d build"
   },
   "dependencies": {
-    "@cerner/terra-aggregate-translations": "^3.0.0",
+    "@cerner/terra-aggregate-translations": "^2.0.1",
     "@cerner/terra-application-docs": "^2.0.0",
     "@cerner/terra-core-docs": "^1.0.0",
-    "@cerner/terra-dev-site": "^8.0.0",
+    "@cerner/terra-dev-site": "^7.0.0",
     "@cerner/terra-docs": "^1.0.0",
     "@cerner/terra-framework-docs": "^1.0.0",
     "@cerner/terra-graphs-docs": "^1.0.1",
@@ -56,14 +56,14 @@
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-final-form": "^6.3.0",
-    "react-intl": "^5.8.2",
+    "react-intl": "^2.8.0",
     "react-router-dom": "^5.0.0",
     "react-tsparticles": "^1.33.1",
     "terra-action-footer": "^2.0.0",
     "terra-action-header": "^2.0.0",
     "terra-aggregator": "^4.0.0",
     "terra-alert": "^4.0.0",
-    "terra-application": "^2.0.0",
+    "terra-application": "^1.14.2",
     "terra-application-navigation": "^1.0.0",
     "terra-arrange": "^3.0.0",
     "terra-avatar": "^3.0.0",
@@ -158,7 +158,7 @@
     "@cerner/stylelint-config-terra": "^4.0.0",
     "@cerner/terra-cli": "^1.1.0",
     "@cerner/terra-open-source-scripts": "^1.1.0",
-    "@cerner/webpack-config-terra": "^3.0.0",
+    "@cerner/webpack-config-terra": "^2.0.0",
     "core-js": "^3.1.3",
     "eslint": "^7.19.0",
     "gh-pages": "^3.0.0",
@@ -170,7 +170,7 @@
     "stylelint": "^13.0.0",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.6.0",
-    "webpack-dev-server": "^4.9.1",
+    "webpack-dev-server": "^3.3.1",
     "webpack-merge": "^5.7.2"
   }
 }


### PR DESCRIPTION
Reverts cerner/terra-ui#485

Reverts Intl v5 updates to fix build failures that happens due to terra-components having reference for terra-application V1.0.0, terra-base and terra-i18n. 

above specified packages are not compatible with react-intl v5.0.0 and causing build to fail ( fails sporadically with same error ). 
```js
Travis Error : 
ERROR in ./node_modules/terra-i18n/lib/intlLoaders.js 8:42-64
296Module not found: Error: Can't resolve 'intlLoaders' in '/home/travis/build/cerner/terra-ui/node_modules/terra-i18n/lib'
297Did you mean './intlLoaders'?

354
355ERROR in ./node_modules/terra-i18n/lib/translationsLoaders.js 8:50-80
356Module not found: Error: Can't resolve 'translationsLoaders' in '/home/travis/build/cerner/terra-ui/node_modules/terra-i18n/lib'
357Did you mean './translationsLoaders'
```

Since terra-application V1.0.0, terra-base and terra-i18n are transitive dependencies being pulled by components like terra-application-navigation and @cerner/terra-core-docs. Reverting PR #485 changes until terra-components are released with react-intl V5 changes.

└─┬ @cerner/terra-core-docs@1.14.1
  ├─┬ terra-base@5.48.1
  │ └── terra-i18n@4.38.1  deduped
  └── terra-i18n@4.38.1 


└─┬ @cerner/terra-core-docs@1.14.1
  └── terra-base@5.48.1  