### PR TITLE
Add clinical lowlight theme

### DIFF
--- a/terra-theme.config.js
+++ b/terra-theme.config.js
@@ -1,5 +1,5 @@
 const themeConfig = {
-  scoped: ['orion-fusion-theme'],
+  scoped: ['orion-fusion-theme', 'clinical-lowlight-theme'],
 };
 
 module.exports = themeConfig;


### PR DESCRIPTION
### Summary
This change adds `clinical-lowlight-theme` to the theme options in the terra-ui site so that consumers can view component documentation with the clinical lowlight theme.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
